### PR TITLE
fix led state

### DIFF
--- a/arduino_code/sketch_may27a/sketch_may27a.ino
+++ b/arduino_code/sketch_may27a/sketch_may27a.ino
@@ -25,7 +25,7 @@ public:
     }
 
     void updateLED() {
-        digitalWrite(led, state() ? LOW : HIGH);
+        digitalWrite(led, !state());
     }
 
     void emit() {

--- a/arduino_code/sketch_may27a/sketch_may27a.ino
+++ b/arduino_code/sketch_may27a/sketch_may27a.ino
@@ -13,17 +13,22 @@ public:
     }
 
     void init() {
-        lastState = (digitalRead(pin) == LOW);
-
         pinMode(led, OUTPUT);
         pinMode(pin, INPUT_PULLUP);
+
+        lastState = digitalRead(pin);
+        updateLED();
     }
 
     bool state() {
-        return (digitalRead(pin) == HIGH);
+        return digitalRead(pin);
     }
 
-    bool emit() {
+    void updateLED() {
+        digitalWrite(led, state() ? LOW : HIGH);
+    }
+
+    void emit() {
       // Run every cycle
       // Change led state depending on input
       
@@ -32,7 +37,7 @@ public:
         lastState = curState;
 
         //printState();
-        digitalWrite(led, curState ? LOW : HIGH);
+        updateLED();
 
         if (curState == HIGH) {
           printId();


### PR DESCRIPTION
This pull request refactors the logic for handling the LED and input pin in `sketch_may27a.ino` to improve code clarity and maintainability. The main change is the introduction of a new `updateLED()` method, which centralizes the LED state update logic and is now used in multiple places. Additionally, the initialization and state handling logic have been streamlined.

**Refactoring and code clarity improvements:**

* Added a new `updateLED()` method to encapsulate the logic for updating the LED state based on the input pin, and replaced direct `digitalWrite` calls with this method throughout the code. [[1]](diffhunk://#diff-d9059c077c631c060b292cd706290088287a5cb4abdc0447804ce31b49f26838L16-R31) [[2]](diffhunk://#diff-d9059c077c631c060b292cd706290088287a5cb4abdc0447804ce31b49f26838L35-R40)
* Updated the `init()` method to set `lastState` and call `updateLED()` after configuring the pin modes, ensuring the LED reflects the initial input state.
* Simplified the `state()` method to directly return the result of `digitalRead(pin)`.
* Changed the `emit()` method to `void` return type, as it no longer returns a value.